### PR TITLE
Added jsProcessor configuration to clientlib

### DIFF
--- a/src/main/resources/SLING-INF/apps/namics/authoring/clientlibs/fieldDependency/js.json
+++ b/src/main/resources/SLING-INF/apps/namics/authoring/clientlibs/fieldDependency/js.json
@@ -6,5 +6,10 @@
   ],
   "dependencies": [
     "granite.jquery"
+  ],
+  "jsProcessor": [
+    "languageIn:ECMASCRIPT6",
+    "min:typescript",
+    "min:gcc"
   ]
 }


### PR DESCRIPTION
In order to use this clientlib with ECMASCRIPT 6, the default minifier
(yui) has to be replaced with the google closure compiler (gcc).